### PR TITLE
v2.X Patch (tested on v2.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![WRToCBanner](WRToCbanner.jpg)
 
-Tested with 1.0
+Tested with v2.5
 
 The White River settlements are looking for new citizens to give extra tools and equipment that they've collected. They are offering to provide a select few survivors access to higher quality equipment in exchange for volunteering to complete various tasks for the settlement. There is a limited supply and these items are only available to those who gain citizenry with White River settlements. In addition to the reward, the player is also offered a small stack of concrete blocks, from the last of the Trader's community inventory to assist in re-establishing a homestead.
 

--- a/WhiteRiverToC_Amelias_Gyrocopter/Config/blocks.xml
+++ b/WhiteRiverToC_Amelias_Gyrocopter/Config/blocks.xml
@@ -19,7 +19,7 @@
 			<property name="Shape" value="ModelEntity"/>
 			<property name="Texture" value="293"/>
 			<!-- <property name="Mesh" value="models"/> -->
-			<property name="Model" value="Entities/OutdoorDecor/coffinWildWestPrefab"/>
+			<property name="Model" value="@:Entities/OutdoorDecor/coffinWildWestPrefab.prefab"/>
 			<property name="HandleFace" value="Bottom"/>
 			<property name="ImposterExchange" value="imposterQuarter" param1="154"/>
 			<property name="IsTerrainDecoration" value="true"/>

--- a/WhiteRiverToC_Amelias_Gyrocopter/Config/loot.xml
+++ b/WhiteRiverToC_Amelias_Gyrocopter/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="ameliaCoffin" count="all">
 			<item name="casinoCoin" count="1000,5000"/>
 			<item name="questitem_toc_amelia_journal_name"/>

--- a/WhiteRiverToC_Amelias_Gyrocopter/Config/quests.xml
+++ b/WhiteRiverToC_Amelias_Gyrocopter/Config/quests.xml
@@ -164,17 +164,12 @@
 				<property name="completion_distance" value="5"/>
 				<property name="nav_object" value="quest"/>
 			</objective>
-			<objective type="RallyPoint">
-				<property name="start_mode" value="Create"/>
-				<property name="phase" value="2"/>
-				<property name="nav_object" value="rally"/>
-			</objective>
-			<objective type="BlockPlace" id="frameShapes:VariantHelper" value="50" phase="3"/>
-			<objective type="BlockUpgrade" id="frameShapes" value="25" phase="4"/>
+			<objective type="BlockPlace" id="frameShapes:VariantHelper" value="50" phase="2"/>
+			<objective type="BlockUpgrade" id="frameShapes" value="25" phase="3"/>
 
-			<action type="SpawnEnemy" id="zombieToCWendigo" value="1" phase="5"/>
-			<action type="SpawnEnemy" id="animalMountainLion" value="2" phase="5"/>
-			<objective type="EntityKill" id="zombieToCWendigo" value="1" phase="5"/>
+			<action type="SpawnEnemy" id="zombieToCWendigo" value="1" phase="4"/>
+			<action type="SpawnEnemy" id="animalMountainLion" value="2" phase="4"/>
+			<objective type="EntityKill" id="zombieToCWendigo" value="1" phase="4"/>
 			<reward type="Quest" id="Reward_of_Amelia_Earharts_Schematics"/>
 			<reward type="Exp" value="500"/>
 		</quest>

--- a/WhiteRiverToC_Bear_Grylls_Claws/Config/quests.xml
+++ b/WhiteRiverToC_Bear_Grylls_Claws/Config/quests.xml
@@ -26,15 +26,9 @@
 				<property name="biome_filter_type" value="SameBiome"/>
 			</objective>
 			
-			<objective type="RallyPoint">
-				<property name="start_mode" value="Create"/>
-				<property name="phase" value="3"/>
-				<property name="nav_object" value="rally"/>
-			</objective>
-			
-			<action type="SpawnEnemy" id="animalBear" value="1" phase="4"/>
-			<objective type="EntityKill" id="animalBear" value="1" phase="4"/>
-			<requirement type="Quests.Requirements.Holding" id="meleeWpnKnucklesT1IronKnuckles" phase="4"/>
+			<action type="SpawnEnemy" id="animalBear" value="1" phase="3"/>
+			<objective type="EntityKill" id="animalBear" value="1" phase="3"/>
+			<requirement type="Quests.Requirements.Holding" id="meleeWpnKnucklesT1IronKnuckles" phase="3"/>
 			
 			<reward type="Item" id="initiateschemitem_toc_claws_name" value="1"/>
 			<reward type="Item" id="questitem_toc_declaration_name" value="1"/>
@@ -63,14 +57,9 @@
 				<property name="completion_distance" value="50"/>
 				<property name="nav_object" value="quest"/>
 			</objective>
-			<objective type="RallyPoint">
-				<property name="start_mode" value="Create"/>
-				<property name="phase" value="3"/>
-				<property name="nav_object" value="rally"/>
-			</objective>
-			<action type="SpawnEnemy" id="animalZombieBear" value="1" phase="4"/>
-			<objective type="EntityKill" id="animalZombieBear" value="1" phase="4"/>
-			<requirement type="Quests.Requirements.Holding" id="meleeWpnKnucklesT3SteelKnuckles" phase="4"/>
+			<action type="SpawnEnemy" id="animalZombieBear" value="1" phase="3"/>
+			<objective type="EntityKill" id="animalZombieBear" value="1" phase="3"/>
+			<requirement type="Quests.Requirements.Holding" id="meleeWpnKnucklesT3SteelKnuckles" phase="3"/>
 			<reward type="Item" id="schemitem_toc_claws_name" value="1"/>
 			<reward type="Item" id="modMeleeClubBurningShaft" ischosen="true" count="1"/>
 			<reward type="LootItem" id="groupQuestcasinoCoinT1" value="1"/>

--- a/WhiteRiverToC_BlackBarts_Dig_Tools/Config/blocks.xml
+++ b/WhiteRiverToC_BlackBarts_Dig_Tools/Config/blocks.xml
@@ -9,7 +9,7 @@
 			<property name="Texture" value="293"/>
 			<!-- Temporary changed by 7DAYSTODIE_JP -->
 			<!-- <property name="Mesh" value="models"/> -->
-			<property name="Model" value="Entities/OutdoorDecor/coffinWildWestPrefab"/>
+			<property name="Model" value="@:Entities/OutdoorDecor/coffinWildWestPrefab.prefab"/>
 			<property name="HandleFace" value="Bottom"/>
 			<property name="ImposterExchange" value="imposterQuarter" param1="154"/>
 			<property name="IsTerrainDecoration" value="true"/>
@@ -20,4 +20,5 @@
 			<property name="FilterTags" value="MC_helpers,SC_loot"/>
 		</block>
 	</append>
+
 </config>

--- a/WhiteRiverToC_BlackBarts_Dig_Tools/Config/loot.xml
+++ b/WhiteRiverToC_BlackBarts_Dig_Tools/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCBlackBartShovel" loot_quality_template="questT3QualTemplate">
 			<item name="questitem_toc_shovel_name"/>
 		</lootgroup>

--- a/WhiteRiverToC_Bunyans_FireAxe/Config/loot.xml
+++ b/WhiteRiverToC_Bunyans_FireAxe/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCBunyan" loot_quality_template="questT3QualTemplate">
 			<item name="item_toc_bunyanaxe_name"/>
 		</lootgroup>

--- a/WhiteRiverToC_Daryls_Crossbow/Config/loot.xml
+++ b/WhiteRiverToC_Daryls_Crossbow/Config/loot.xml
@@ -2,7 +2,7 @@
 	<append xpath="/lootcontainers/lootgroup[@name='randomEliteQuests']">
 		<item name="elitequestitem_toc_daryl_name" count="1"/>
 	</append>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupQuestToCDarylArrowsVet">
 			<item name="ammoCrossbowBoltIron" count="20,50"/>
 			<item name="ammoCrossbowBoltFlaming" count="20,30"/>

--- a/WhiteRiverToC_Deschains_Revolver/Config/loot.xml
+++ b/WhiteRiverToC_Deschains_Revolver/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCDeschain" loot_quality_template="questT3QualTemplate">
 			<item name="itemreward_toc_desch_name" count="1"/>
 		</lootgroup>

--- a/WhiteRiverToC_Dundees_Knife/Config/loot.xml
+++ b/WhiteRiverToC_Dundees_Knife/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCDundeeInitiate" loot_quality_template="questT1QualTemplate">
 			<item name="item_toc_dundeeknife_name"/>
 		</lootgroup>

--- a/WhiteRiverToC_Everdeens_Arrows/Config/loot.xml
+++ b/WhiteRiverToC_Everdeens_Arrows/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCEverdeenArrows" loot_quality_template="questT3QualTemplate">
 			<item name="item_toc_earrows_name" count="50,150"/>
 		</lootgroup>

--- a/WhiteRiverToC_Guptas_Bandages/Config/loot.xml
+++ b/WhiteRiverToC_Guptas_Bandages/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCGuptas" loot_quality_template="questT3QualTemplate">
 			<item name="medicalGuptaFirstAidBandage" count="2,5"/>
 		</lootgroup>

--- a/WhiteRiverToC_Jasons_Machete/Config/loot.xml
+++ b/WhiteRiverToC_Jasons_Machete/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCJason" loot_quality_template="questT3QualTemplate">
 			<item name="initiateitem_toc_jason_name"/>
 		</lootgroup>

--- a/WhiteRiverToC_Kuvas_Armor/Config/blocks.xml
+++ b/WhiteRiverToC_Kuvas_Armor/Config/blocks.xml
@@ -11,7 +11,7 @@
 			<property name="Shape" value="ModelEntity"/>
 			<property name="Texture" value="293"/>
 			<!-- <property name="Mesh" value="models"/> -->
-			<property name="Model" value="Entities/OutdoorDecor/coffinWildWestPrefab" param1="main_mesh"/>
+			<property name="Model" value="@:Entities/OutdoorDecor/coffinWildWestPrefab.prefab" param1="main_mesh"/>
 			<property name="HandleFace" value="Bottom"/>
 			<property name="ImposterExchange" value="imposterQuarter" param1="154"/>
 			<property name="IsTerrainDecoration" value="true"/>

--- a/WhiteRiverToC_Kuvas_Armor/Config/loot.xml
+++ b/WhiteRiverToC_Kuvas_Armor/Config/loot.xml
@@ -1,5 +1,5 @@
 <config>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCKuvaChest" loot_quality_template="questT1QualTemplate">
 			<item name="item_toc_kuvared_chest_name"/>
 		</lootgroup>

--- a/WhiteRiverToC_Molino_Glass/Config/blocks.xml
+++ b/WhiteRiverToC_Molino_Glass/Config/blocks.xml
@@ -7,7 +7,7 @@
 			<property name="Material" value="MglassBulletproof"/>
 			<property name="Shape" value="New"/>
 			<property name="LightOpacity" value="2"/>
-			<property name="Model" value="cube_glass"/>
+			<property name="Model" value="@:Shapes/cube_glass.fbx"/>
 			<property name="Mesh" value="transparent"/>
 			<property name="Texture" value="285"/>
 			<!-- Transparent Texture -->
@@ -25,7 +25,7 @@
 		</block>
 		<block name="questblock_toc_glassNonFuzzyBulletproofCTRPlate">
 			<property name="Extends" value="questblock_toc_glassNonFuzzyBulletproofMaster"/>
-			<property name="Model" value="plate_centered"/>
+			<property name="Model" value="@:Shapes/plate_centered.fbx"/>
 			<property name="Place" value="TowardsPlacerInverted"/>
 			<property name="SortOrder2" value="0160"/>
 			<!-- SortShape -->
@@ -47,7 +47,7 @@
 		</block>
 		<block name="questblock_toc_glassNonFuzzyBulletproofPlate">
 			<property name="Extends" value="questblock_toc_glassNonFuzzyBulletproofMaster"/>
-			<property name="Model" value="plate_glass"/>
+			<property name="Model" value="@:Shapes/plate_glass.fbx"/>
 			<property name="Place" value="TowardsPlacerInverted"/>
 			<property name="ImposterExchange" value="imposterPlate" param1="170"/>
 			<!-- ShadowColour -->
@@ -64,17 +64,18 @@
 		</block>
 		<block name="questblock_toc_glassNonFuzzyBulletproofRamp">
 			<property name="Extends" value="questblock_toc_glassNonFuzzyBulletproofMaster"/>
-			<property name="Model" value="ramp_glass"/>
+			<property name="Model" value="@:Shapes/ramp_glass.fbx"/>
 			<property name="CustomIcon" value="glassBulletproofRamp"/>
 			<property name="ImposterExchange" value="imposterRamp" param1="170"/>
 			<!-- ShadowColour -->
 		</block>
 		<block name="questblock_toc_glassNonFuzzyBulletproofPlateCurved">
 			<property name="Extends" value="questblock_toc_glassNonFuzzyBulletproofMaster"/>
-			<property name="Model" value="plate_corner_round_1m"/>
+			<property name="Model" value="@:Shapes/plate_corner_round_1m.fbx"/>
 			<property name="CustomIcon" value="glassBulletproofPlateCurved"/>
 			<property name="ImposterExchange" value="imposterBlock" param1="170"/>
 			<!-- ShadowColour -->
 		</block>
 	</append>
+
 </config>

--- a/WhiteRiverToC_Molino_Glass/Config/loot.xml
+++ b/WhiteRiverToC_Molino_Glass/Config/loot.xml
@@ -2,7 +2,7 @@
 	<append xpath="/lootcontainers/lootgroup[@name='randomEliteQuests']">
 		<item name="elitequestitem_toc_glassNonFuzzyBulletproofBlockVariantHelper_name" count="1"/>
 	</append>
-	<append xpath="lootcontainers">
+	<append xpath="/lootcontainers">
 		<lootgroup name="groupWhiteRiverTOCMolinoVet" loot_quality_template="questT3QualTemplate">
 			<item name="questblock_toc_glassNonFuzzyBulletproofBlockVariantHelper" count="50,100"/>
 		</lootgroup>

--- a/WhiteRiverToC_Pavlichenkos_Rifle/Config/blocks.xml
+++ b/WhiteRiverToC_Pavlichenkos_Rifle/Config/blocks.xml
@@ -10,7 +10,7 @@
 			<property name="Texture" value="293"/>
 			<!-- Temporary changed by 7DAYSTODIE_JP -->
 			<!-- <property name="Mesh" value="models"/> -->
-			<property name="Model" value="Entities/OutdoorDecor/coffinWildWestPrefab" param1="main_mesh"/>
+			<property name="Model" value="@:Entities/OutdoorDecor/coffinWildWestPrefab.prefab" param1="main_mesh"/>
 			<property name="HandleFace" value="Bottom"/>
 			<property name="ImposterExchange" value="imposterQuarter" param1="154"/>
 			<property name="IsTerrainDecoration" value="true"/>
@@ -30,7 +30,7 @@
 			<property name="Texture" value="293"/>
 			<!-- Temporary changed by 7DAYSTODIE_JP -->
 			<!-- <property name="Mesh" value="models"/> -->
-			<property name="Model" value="Entities/OutdoorDecor/coffinWildWestPrefab" param1="main_mesh"/>
+			<property name="Model" value="@:Entities/OutdoorDecor/coffinWildWestPrefab.prefab" param1="main_mesh"/>
 			<property name="HandleFace" value="Bottom"/>
 			<property name="ImposterExchange" value="imposterQuarter" param1="154"/>
 			<property name="IsTerrainDecoration" value="true"/>

--- a/WhiteRiverToC_Remingtons_Steel_Ammo/Config/blocks.xml
+++ b/WhiteRiverToC_Remingtons_Steel_Ammo/Config/blocks.xml
@@ -16,7 +16,7 @@
 			<property name="Shape" value="ModelEntity"/>
 			<!-- <property name="Mesh" value="models"/> -->
 			<property name="Path" value="solid"/>
-			<property name="Model" value="Entities/Traps/AutoTurret/autoTurretSMGPrefab"/>
+			<property name="Model" value="@:Entities/Traps/AutoTurret/autoTurretSMGPrefab.prefab"/>
 			<property name="OnlySimpleRotations" value="true"/>
 			<!-- the targeting math will NOT work if it's not upright -->
 			<property name="AmmoItem" value="ammo762mmBulletFMJSteelRemington"/>

--- a/WhiteRiverToC_Spirit_of_Vengence/Config/quests.xml
+++ b/WhiteRiverToC_Spirit_of_Vengence/Config/quests.xml
@@ -39,15 +39,9 @@
 				<property name="biome_filter_type" value="SameBiome"/>
 			</objective>
 
-			<objective type="RallyPoint">
-				<property name="start_mode" value="Create"/>
-				<property name="phase" value="2"/>
-				<property name="nav_object" value="rally"/>
-			</objective>
-
-			<action type="SpawnEnemy" id="ZombieSpiritJuggernaut" value="1" phase="3"/>
-			<action type="SpawnEnemy" id="animalWolf" value="2" phase="3"/>
-			<objective type="EntityKill" id="ZombieSpiritJuggernaut" value="1" phase="3"/>
+			<action type="SpawnEnemy" id="ZombieSpiritJuggernaut" value="1" phase="2"/>
+			<action type="SpawnEnemy" id="animalWolf" value="2" phase="2"/>
+			<objective type="EntityKill" id="ZombieSpiritJuggernaut" value="1" phase="2"/>
 
 			<reward type="Item" id="questwrit_spirit_vengeance_name" value="1"/>
 			<reward type="Exp" value="500"/>


### PR DESCRIPTION
Fixed model paths in various blocks.xml in line with v2 standard
Standardised xpath lootcontainers
Fixed rally points not working in v2 (removed rally point objective in favour of goto area objective and edited subsequent objective phases to reflect this)